### PR TITLE
Solve_zero_padding

### DIFF
--- a/main_kilosort.m
+++ b/main_kilosort.m
@@ -61,6 +61,12 @@ rez.good = get_good_units(rez);
 
 fprintf('found %d good units \n', sum(rez.good>0))
 
+% correct times for the deleted batches
+rez=correct_time(rez);
+
+% rewrite temp_wh to the original length
+rewrite_temp_wh(ops)
+
 % write to Phy
 fprintf('Saving results to Phy  \n')
 rezToPhy(rez, rootZ);

--- a/postProcess/correct_time.m
+++ b/postProcess/correct_time.m
@@ -1,0 +1,13 @@
+function rez = correct_time(rez)
+
+ops = rez.ops;
+NT = ops.NT;
+deleted_batches = ops.deleted_batches;
+st3 = rez.st3;
+
+for q=1:numel(deleted_batches)
+    entry_point=deleted_batches(q)*NT-NT;
+    st3(st3(:,1)>entry_point,1)=st3(st3(:,1)>entry_point,1)+NT;
+end
+
+rez.st3=st3; 


### PR DESCRIPTION
Possible solution to #275 #274 #231. Kilosort doesn't like zero padding in the raw binaries. Not sure this is the best way of implementing this! I would rather not have changed main_kilosort.m.

When creating temp_wh.dat in preprocessDataSub I ignore batches that contain zero_padding in all channels, I save the indices of the ignored batches in rez.ops.deleted_batches.
At the end of the post processing I adjust the spike times to account for the deleted batches (postProcess/correct_time.m) and rewrite temp_wh (utils/rewrite_temp_wh) as temp_wh is now used in phy.

This is an example binary that breaks current kilosort because of zero padding: https://charitede-my.sharepoint.com/:u:/g/personal/roberto_de-filippo_charite_de/EVhFyZvJuS1EnzglCDazP-gBGIrWaFvfXwrDJuugZfxYOg?e=a7N3VD