### PR TITLE
README: Permalinks for prior releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 Now is the best time to post feedback (good or bad) so please use Github issues freely! 
 
 For older versions, please see Github releases:   
-*updated from Kilosort2.5 on Jan 30, 2021.*  
-*updated from Kilosort2 on Oct 28, 2020.* 
+
+* [Kilosort 2.5](https://github.com/MouseLand/Kilosort/releases/tag/v2.5) on Jan 30, 2021.
+* [Kilosort 2.0](https://github.com/MouseLand/Kilosort/releases/tag/v2.0) on Oct 28, 2020.
 
 ![](https://github.com/MouseLand/Kilosort/blob/main/Docs/img/frame_full.png)
 


### PR DESCRIPTION
How about links to the release pages for the prior releases in the README?