### PR TITLE
enable bypassing filtering in data preprocessing

### DIFF
--- a/preProcess/align_block2.m
+++ b/preProcess/align_block2.m
@@ -6,7 +6,7 @@ function [imin,yblk, F0, F0m] = align_block2(F, ysamp, nblocks)
 Nbatches = size(F,3);
 
 % look up and down this many y bins to find best alignment
-n = 15;
+n = 30;
 dc = zeros(2*n+1, Nbatches);
 dt = -n:n;
 
@@ -65,7 +65,7 @@ yblk = zeros(length(ifirst), 1);
 
 % for each small block, we only look up and down this many samples to find
 % nonrigid shift
-n = 5;
+n = 30;
 dt = -n:n;
 
 % this part determines the up/down covariance for each block without

--- a/preProcess/align_nonrigid.m
+++ b/preProcess/align_nonrigid.m
@@ -3,8 +3,8 @@ function [nrshifts,F0] = align_nonrigid(F,ishift,iblk,sig)
 %   Detailed explanation goes here
 
 if nargin==3
-    % -4:4 pixels = -20:20 um sptial gaussian(5um spaceing), -8:8 pixels = -16:16 sec temporal gaussian(~2sec batch)
-    sig=[2,4];
+    % -10:10 pixels = -50:50 um sptial gaussian(5um spaceing), -3:3 pixels = -6:6 sec temporal gaussian(~2sec batch)
+    sig=[5,1.5];
 end
 
 nbatch = size(F,3);

--- a/preProcess/align_nonrigid.m
+++ b/preProcess/align_nonrigid.m
@@ -1,0 +1,71 @@
+function [nrshifts,F0] = align_nonrigid(F,ishift,iblk,sig)
+%ALIGN_NONRIGID Diffeomorphic Demons non-rigid image registration
+%   Detailed explanation goes here
+
+if nargin==3
+    % -4:4 pixels = -20:20 um sptial gaussian(5um spaceing), -8:8 pixels = -16:16 sec temporal gaussian(~2sec batch)
+    sig=[2,4];
+end
+
+nbatch = size(F,3);
+ndepth = size(F,1);
+brshifts = interp1(iblk, ishift', 1:ndepth, 'makima', 'extrap'); % block rigid shifts on frame depths
+
+% spike amplitude image
+I = zeros(ndepth,nbatch);
+for i=1:nbatch
+    for j=1:ndepth
+        I(j,i)= sum(F(j,:,i).*(1:size(F,2)))/sum(F(j,:,i)); % mean amplitude
+    end
+end
+bI = imwarp(I,cat(3,zeros(size(brshifts)),-brshifts));
+plotdrift(flipud(-brshifts),flipud(I),flipud(bI),'Block-Rigid Registration');
+
+% non-rigid image registration
+[df,F0] = nonrigid(F);
+nrshifts = cellfun(@(x)median(x(:,:,2),2),df,'UniformOutput',false); % displacement field on depths
+nrshifts = [nrshifts{:}];
+
+% high freqency shifts on both spatial and temporal are less likely true,
+% and more likely reflect noise in spike amplitude distribution: F
+if ~isempty(sig)
+    nrshifts = imgaussfilt(nrshifts,sig,'FilterDomain','frequency');
+end
+dI = imwarp(I,cat(3,zeros(size(nrshifts)),nrshifts));
+plotdrift(flipud(nrshifts),flipud(I),flipud(dI),'Non-Rigid Registration');
+nrshifts=-nrshifts';
+
+    function plotdrift(d,im,dcim,titlestr)
+        if nargin==3
+            titlestr='';
+        end
+        
+        figure('units','normalized','position',[0.15 0.4 0.7 0.35])
+        t=tiledlayout(1,3,'TileSpacing','compact','Padding','compact');
+        
+        nexttile
+        imagesc(d)
+        title('Estimated drift')
+        set(gca,'yticklabel',[])
+        box off
+        
+        nexttile
+        imagesc(im)
+        title('Drift map')
+        set(gca,'yticklabel',[])
+        box off
+        
+        nexttile
+        imagesc(dcim)
+        title('Estimated corrected drift map')
+        set(gca,'yticklabel',[])
+        box off
+        
+        title(t,titlestr)
+        xlabel(t,'batch number')
+        ylabel(t,'depth')
+        drawnow
+    end
+
+end
+

--- a/preProcess/datashift2.m
+++ b/preProcess/datashift2.m
@@ -105,7 +105,7 @@ end
 if getOr(ops, 'fig', 1)  
     figure;
     set(gcf, 'Color', 'w')
-    coloroder(turbo(size(imin,2)))
+    colororder(turbo(size(imin,2)))
     
     % plot the shift trace in um
     plot(imin * dd)

--- a/preProcess/datashift2.m
+++ b/preProcess/datashift2.m
@@ -105,6 +105,7 @@ end
 if getOr(ops, 'fig', 1)  
     figure;
     set(gcf, 'Color', 'w')
+    coloroder(turbo(size(imin,2)))
     
     % plot the shift trace in um
     plot(imin * dd)
@@ -131,7 +132,7 @@ if getOr(ops, 'fig', 1)
     xlabel('time (sec)')
     ylabel('spike position (um)')
     title('Drift map')
-    
+    drawnow
 end
 %%
 % convert to um 
@@ -154,6 +155,7 @@ else
 end
 % keep track of dshift 
 rez.dshift = dshift;
+rez.yblk = yblk;
 % keep track of original spikes
 rez.st0 = st3;
 

--- a/preProcess/datashift2.m
+++ b/preProcess/datashift2.m
@@ -134,6 +134,11 @@ if getOr(ops, 'fig', 1)
     title('Drift map')
     drawnow
 end
+
+% non-rigid registration
+[imin,F0] = align_nonrigid(F,imin,ceil(yblk/dd));
+yblk = ysamp';
+F0m=F0;
 %%
 % convert to um 
 dshift = imin * dd;

--- a/preProcess/gpufilter.m
+++ b/preProcess/gpufilter.m
@@ -6,28 +6,32 @@ function datr = gpufilter(buff, ops, chanMap)
 % ops.fs and ops.fshigh are sampling and high-pass frequencies respectively
 % if ops.fslow is present, it is used as low-pass frequency (discouraged)
 
-% set up the parameters of the filter
-if isfield(ops,'fslow')&&ops.fslow<ops.fs/2
-    [b1, a1] = butter(3, [ops.fshigh/ops.fs,ops.fslow/ops.fs]*2, 'bandpass'); % butterworth filter with only 3 nodes (otherwise it's unstable for float32)
-else
-    [b1, a1] = butter(3, ops.fshigh/ops.fs*2, 'high'); % the default is to only do high-pass filtering at 150Hz
-end
-
 dataRAW = gpuArray(buff); % move int16 data to GPU
 dataRAW = dataRAW';
 dataRAW = single(dataRAW); % convert to float32 so GPU operations are fast
 dataRAW = dataRAW(:, chanMap); % subsample only good channels
 
-% subtract the mean from each channel
-dataRAW = dataRAW - mean(dataRAW, 1); % subtract mean of each channel
-
-% CAR, common average referencing by median
-if getOr(ops, 'CAR', 1)
-    dataRAW = dataRAW - median(dataRAW, 2); % subtract median across channels
+if getOr(ops,'filtering',1)
+    % subtract the mean from each channel
+    dataRAW = dataRAW - mean(dataRAW, 1); % subtract mean of each channel
+    
+    % CAR, common average referencing by median
+    if getOr(ops, 'CAR', 1)
+        dataRAW = dataRAW - median(dataRAW, 2); % subtract median across channels
+    end
+    
+    % set up the parameters of the filter
+    if isfield(ops,'fslow')&&ops.fslow<ops.fs/2
+        [b1, a1] = butter(3, [ops.fshigh/ops.fs,ops.fslow/ops.fs]*2, 'bandpass'); % butterworth filter with only 3 nodes (otherwise it's unstable for float32)
+    else
+        [b1, a1] = butter(3, ops.fshigh/ops.fs*2, 'high'); % the default is to only do high-pass filtering at 150Hz
+    end
+    
+    % next four lines should be equivalent to filtfilt (which cannot be used because it requires float64)
+    datr = filter(b1, a1, dataRAW); % causal forward filter
+    datr = flipud(datr); % reverse time
+    datr = filter(b1, a1, datr); % causal forward filter again
+    datr = flipud(datr); % reverse time back
+else
+    datr = dataRAW;
 end
-
-% next four lines should be equivalent to filtfilt (which cannot be used because it requires float64)
-datr = filter(b1, a1, dataRAW); % causal forward filter
-datr = flipud(datr); % reverse time
-datr = filter(b1, a1, datr); % causal forward filter again
-datr = flipud(datr); % reverse time back

--- a/preProcess/nonrigid.m
+++ b/preProcess/nonrigid.m
@@ -1,0 +1,34 @@
+function [disp,m] = nonrigid(F,N,S)
+%NONRIGID Summary of this function goes here
+%   Detailed explanation goes here
+
+if nargin==1
+    N = [128 64 32 16]; % iteration number for each level of pyramid
+    S = 1.5; % smoothing
+elseif nargin==2
+    S = 1.5;
+end
+
+nt = size(F,3);
+if(nt==1)
+    m = F(:,:,1);
+    disp = {zeros([size(m) 2])};
+elseif (nt==2) % align first to second frame
+    f1 = F(:,:,1);
+    f2 = F(:,:,2);
+    [d,f12] = imregdemons(f1,f2,N,'AccumulatedFieldSmoothing',S,'PyramidLevels',length(N),'DisplayWaitBar',false);
+    m = (f12+f2)/2;
+    disp = {d zeros([size(f1) 2])};
+else
+    idx1 = 1:floor(nt/2); % split frames in two
+    idx2 = floor(nt/2)+1 : nt; % recursive alignment
+    [d1,f1] = nonrigid(F(:,:,idx1));
+    [d2,f2] = nonrigid(F(:,:,idx2));
+    [d,f12] = imregdemons(f1,f2,N,'AccumulatedFieldSmoothing',S,'PyramidLevels',length(N),'DisplayWaitBar',false);
+    m = (f12+f2)/2;
+    d1 = cellfun(@(x)x+d,d1,'UniformOutput',false); % concatenate distortions
+    disp = [d1 d2];
+end
+
+end
+


### PR DESCRIPTION
Sometimes, the binary data have already been filtered and CARed, for example using [CatGT](https://billkarsh.github.io/SpikeGLX/help/catgt_tshift/catgt_tshift/), this bypassing could prevent doing it twice.