### PR TITLE
Little fix for 'eig did not converge' crash (Kilosort 2.0)

### DIFF
--- a/mainLoop/runTemplates.m
+++ b/mainLoop/runTemplates.m
@@ -95,7 +95,14 @@ for j = 1:Nfilt
     
     UA = reshape(rez.UA(:, j, :, :), [], Nbatches);
     UA = gpuArray(UA);
-    [A, B, C] = svdecon(UA);
+
+    try
+        [A, B, C] = svdecon(UA);
+    catch ME
+        % warning(ME.message);
+        [A, B, C] = svd(UA, 'econ');
+    end
+    
     % U_a times U_b results in a reconstruction of the time components
     rez.U_a(:,:,j) = gather(A(:, 1:nKeep) * B(1:nKeep, 1:nKeep));
     rez.U_b(:,:,j) = gather(C(:, 1:nKeep));

--- a/utils/svdecon.m
+++ b/utils/svdecon.m
@@ -20,8 +20,14 @@ end
 
 if  m <= n
     C = X*X';
-    [U,D] = eig(C);
-    
+
+    try
+        [U,D] = eig(C);
+    catch ME
+        % warning(ME.message);
+        [U,D] = eig(gather(C), 'nobalance');
+    end
+
     clear C;
     
     [d,ix] = sort(abs(diag(D)),'descend');
@@ -39,8 +45,15 @@ if  m <= n
         V = gather(V);
     end
 else
-    C = X'*X; 
-    [V,D] = eig(C);
+    C = X'*X;
+
+    try
+        [V,D] = eig(C);
+    catch ME
+        % warning(ME.message);
+        [V,D] = eig(gather(C), 'nobalance');
+    end
+
     D = gather(D);
     V = gather(V);
     clear C;


### PR DESCRIPTION
These changes do not change the default Kilosort 2.0 behaviour, but adds alternatives in case of a crash to try to make the run successful.

If these changes still provide a crash, in my experience increasing the 'NT' parameter helps :)