### PR TITLE
Jacob/amplitudes

### DIFF
--- a/kilosort/io.py
+++ b/kilosort/io.py
@@ -158,7 +158,9 @@ def save_to_phy(st, clu, tF, Wall, probe, ops, imin, results_dir=None,
     # whitening matrix ** saving real whitening matrix doesn't work with phy currently
     whitening_mat = ops['Wrot'].cpu().numpy()
     np.save((results_dir / 'whitening_mat_dat.npy'), whitening_mat)
-    whitening_mat = 0.005 * np.eye(len(chan_map), dtype='float32')
+    # NOTE: commented out for reference, this was different in KS 2.5 because
+    #       the binary file was already whitened.
+    # whitening_mat = 0.005 * np.eye(len(chan_map), dtype='float32')
     whitening_mat_inv = np.linalg.inv(whitening_mat + 1e-5 * np.eye(whitening_mat.shape[0]))
     np.save((results_dir / 'whitening_mat.npy'), whitening_mat)
     np.save((results_dir / 'whitening_mat_inv.npy'), whitening_mat_inv)

--- a/kilosort/io.py
+++ b/kilosort/io.py
@@ -197,12 +197,6 @@ def save_to_phy(st, clu, tF, Wall, probe, ops, imin, results_dir=None,
     template_amplitudes = ((Wall**2).sum(axis=(-2,-1))**0.5).cpu().numpy()
     templates = (Wall.unsqueeze(-1).cpu() * ops['wPCA'].cpu()).sum(axis=-2).numpy()
     templates = templates.transpose(0,2,1)
-    # normalize templates by amplitude
-    # TODO: check if this helps / hurts going between snippets and templates
-    #       scale should not change when switching between
-    # TODO: post issue on phy github asking where 'amp' is actually coming from,
-    #        other issue answers are old and don't seem to point anywhere relevant
-    templates = templates / template_amplitudes[:, np.newaxis, np.newaxis]
     templates_ind = np.tile(np.arange(Wall.shape[1])[np.newaxis, :], (templates.shape[0],1))
     np.save((results_dir / 'similar_templates.npy'), similar_templates)
     np.save((results_dir / 'templates.npy'), templates)

--- a/kilosort/io.py
+++ b/kilosort/io.py
@@ -155,7 +155,7 @@ def save_to_phy(st, clu, tF, Wall, probe, ops, imin, results_dir=None,
     np.save((results_dir / 'channel_map.npy'), chan_map)
     np.save((results_dir / 'channel_positions.npy'), channel_positions)
 
-    # whitening matrix ** saving real whitening matrix doesn't work with phy currently
+    # whitening matrix
     whitening_mat = ops['Wrot']
     np.save((results_dir / 'whitening_mat_dat.npy'), whitening_mat.cpu())
     # NOTE: commented out for reference, this was different in KS 2.5 because


### PR DESCRIPTION
Updated variables exported to phy:
1) templates are normalized (but not unwhitened) before saving.
2) templates are unwhitened when computing cluster amplitudes.
3) actual whitening matrix inverse is saved.