### PR TITLE
clustering_qr.kmeans_plusplus explicit tensors deletion

### DIFF
--- a/kilosort/clustering_qr.py
+++ b/kilosort/clustering_qr.py
@@ -212,7 +212,7 @@ def kmeans_plusplus(Xg, niter = 200, seed = 1, device=torch.device('cuda'), clea
         vexp0[ix] = vexp[ix,imax]
         iclust[ix] = j
 
-        if clear_cache:
+        if clear_cache and (Xg.element_size() * Xg.nelement() )/ (1024 ** 3) > 4: # we explicitly delete only if tensor is bigger than 4GB
             del vexp, dexp
 
     return iclust

--- a/kilosort/clustering_qr.py
+++ b/kilosort/clustering_qr.py
@@ -120,7 +120,7 @@ def Mstats(M, device=torch.device('cuda')):
 
 
 def cluster(Xd, iclust = None, kn = None, nskip = 20, n_neigh = 10, nclust = 200, 
-            seed = 1, niter = 200, lam = 0, device=torch.device('cuda')):    
+            seed = 1, niter = 200, lam = 0, device=torch.device('cuda'), clear_cache=False):    
 
     if kn is None:
         kn, M = neigh_mat(Xd, nskip = nskip, n_neigh = n_neigh)
@@ -140,7 +140,7 @@ def cluster(Xd, iclust = None, kn = None, nskip = 20, n_neigh = 10, nclust = 200
     tones2 = torch.ones((NN, n_neigh), device = device)
 
     if iclust is None:
-        iclust_init =  kmeans_plusplus(Xg, niter = nclust, seed = seed, device=device)
+        iclust_init =  kmeans_plusplus(Xg, niter = nclust, seed = seed, device=device, clear_cache=clear_cache)
         iclust = iclust_init.clone()
     else:
         iclust_init = iclust.clone()
@@ -162,7 +162,7 @@ def cluster(Xd, iclust = None, kn = None, nskip = 20, n_neigh = 10, nclust = 200
     return iclust, isub, M, iclust_init
 
 
-def kmeans_plusplus(Xg, niter = 200, seed = 1, device=torch.device('cuda')):
+def kmeans_plusplus(Xg, niter = 200, seed = 1, device=torch.device('cuda'), clear_cache=False):
     #Xg = torch.from_numpy(Xd).to(dev)    
     vtot = (Xg**2).sum(1)
 
@@ -211,6 +211,9 @@ def kmeans_plusplus(Xg, niter = 200, seed = 1, device=torch.device('cuda')):
         mu[j] = Xg[ix].mean(0)
         vexp0[ix] = vexp[ix,imax]
         iclust[ix] = j
+
+        if clear_cache:
+            del vexp, dexp
 
     return iclust
 
@@ -384,7 +387,7 @@ def run(ops, st, tF,  mode = 'template', device=torch.device('cuda'),
 
                 # find new clusters
                 iclust, iclust0, M, iclust_init = cluster(Xd, nskip=nskip, lam=1,
-                                                          seed=5, device=device)
+                                                          seed=5, device=device, clear_cache=clear_cache)
                 if clear_cache:
                     gc.collect()
                     torch.cuda.empty_cache()


### PR DESCRIPTION
Expand the reach of clear_cache to clustering_qr.kmeans_plusplus. 
Somehow I still get OOM at https://github.com/MouseLand/Kilosort/blob/b2f5ded41aaa7e13ed44bf43ecf488770ef54753/kilosort/clustering_qr.py#L202 in one particular session. With this explicit cache cleaning I manage to process the session.

The error happens with a specific Xg matrix that takes 5GB of GPU memory. I have 12GB of memory on my RTX 4070.

The explicit deletion of vexp and dexp will slow down the loop therefore happens only if the tensor is bigger than 4GB. 

dexp and vexp are reassigned within each loop but somehow the GPU does not delete immediately the previous tensor. It is enough to delete the variables, it is not necessary to use directly torch.cuda.empty_cache(), that would further slow doen the loop.

Related to #746, possibly #771