### PR TITLE
fix logger when running in a for loop

### DIFF
--- a/kilosort/run_kilosort.py
+++ b/kilosort/run_kilosort.py
@@ -309,7 +309,7 @@ def setup_logger(results_dir):
                         format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
                         datefmt='%m-%d %H:%M',
                         filename=results_dir/'kilosort4.log',
-                        filemode='w')
+                        filemode='w', force=True)
 
     # define a Handler which writes INFO messages or higher to the sys.stderr
     console = logging.StreamHandler()


### PR DESCRIPTION
Hi,

Right now if I run the function run_kilosort  in a for loop the logger will create a log file only in the first for loop. The logging.basicConfig() function only configures the logger once and subsequent calls to basicConfig() have no effect unless you explicitly force it to reconfigure. This is fixed by simply adding the arg force=True.