### PR TITLE
Fix OMP_NUM_THREADS bug

### DIFF
--- a/kilosort/spikedetect.py
+++ b/kilosort/spikedetect.py
@@ -75,12 +75,10 @@ def extract_wPCA_wTEMP(ops, bfile, nt=61, twav_min=20, Th_single_ch=6, nskip=25,
         warnings.filterwarnings("ignore", message="")
         # Prevents memory leak for KMeans when using MKL on Windows
         msg = 'KMeans is known to have a memory leak on Windows with MKL'
-        nthread = os.environ.get('OMP_NUM_THREADS', msg)
-        os.environ['OMP_NUM_THREADS'] = '7'
+        nthread = os.environ.get('OMP_NUM_THREADS', "7")
         model = KMeans(n_clusters=ops['settings']['n_templates'], n_init = 10).fit(clips)
         wTEMP = torch.from_numpy(model.cluster_centers_).to(device).float()
         wTEMP = wTEMP / (wTEMP**2).sum(1).unsqueeze(1)**.5
-        os.environ['OMP_NUM_THREADS'] = nthread
 
     return wPCA, wTEMP
 

--- a/kilosort/spikedetect.py
+++ b/kilosort/spikedetect.py
@@ -75,11 +75,15 @@ def extract_wPCA_wTEMP(ops, bfile, nt=61, twav_min=20, Th_single_ch=6, nskip=25,
         warnings.filterwarnings("ignore", message="")
         # Prevents memory leak for KMeans when using MKL on Windows
         msg = 'KMeans is known to have a memory leak on Windows with MKL'
-        nthread = os.environ.get('OMP_NUM_THREADS', "7")
+        nthread = os.environ.get('OMP_NUM_THREADS')
+        os.environ['OMP_NUM_THREADS'] = '7'
         model = KMeans(n_clusters=ops['settings']['n_templates'], n_init = 10).fit(clips)
         wTEMP = torch.from_numpy(model.cluster_centers_).to(device).float()
         wTEMP = wTEMP / (wTEMP**2).sum(1).unsqueeze(1)**.5
-        os.environ['OMP_NUM_THREADS'] = nthread
+        if nthread is not None:
+            os.environ['OMP_NUM_THREADS'] = nthread
+        else:
+            os.environ.pop('OMP_NUM_THREADS')
 
     return wPCA, wTEMP
 

--- a/kilosort/spikedetect.py
+++ b/kilosort/spikedetect.py
@@ -72,9 +72,9 @@ def extract_wPCA_wTEMP(ops, bfile, nt=61, twav_min=20, Th_single_ch=6, nskip=25,
     wPCA = torch.from_numpy(model.components_).to(device).float()
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="")
-        # Prevents memory leak for KMeans when using MKL on Windows
         msg = 'KMeans is known to have a memory leak on Windows with MKL'
+        warnings.filterwarnings("ignore", message=msg)
+        # Prevents memory leak for KMeans when using MKL on Windows
         nthread = os.environ.get('OMP_NUM_THREADS')
         os.environ['OMP_NUM_THREADS'] = '7'
         model = KMeans(n_clusters=ops['settings']['n_templates'], n_init = 10).fit(clips)

--- a/kilosort/spikedetect.py
+++ b/kilosort/spikedetect.py
@@ -79,6 +79,7 @@ def extract_wPCA_wTEMP(ops, bfile, nt=61, twav_min=20, Th_single_ch=6, nskip=25,
         model = KMeans(n_clusters=ops['settings']['n_templates'], n_init = 10).fit(clips)
         wTEMP = torch.from_numpy(model.cluster_centers_).to(device).float()
         wTEMP = wTEMP / (wTEMP**2).sum(1).unsqueeze(1)**.5
+        os.environ['OMP_NUM_THREADS'] = nthread
 
     return wPCA, wTEMP
 


### PR DESCRIPTION
Hi,

if OMP_NUM_THREADS is not set already it will be set to a string instead of a int here below.
https://github.com/MouseLand/Kilosort/blob/326a00dd2c6f130fff96505295b88965cc09a21e/kilosort/spikedetect.py#L74-L83
This was happening on my windows machine and crashing the code. 
7 seems to work fine, the msg text is currently unused, not sure it is important to keep it or not.