### PR TITLE
NaN typo in swarmsplitter.py (Numpy)

### DIFF
--- a/kilosort/swarmsplitter.py
+++ b/kilosort/swarmsplitter.py
@@ -93,7 +93,7 @@ def split(Xd, xtree, tstat, iclust, my_clus, verbose = True, meta = None):
         ix2 = np.isin(iclust, my_clus[xtree[kk, 1]])
 
         criterion = 0
-        score = np.NaN
+        score = np.nan
         if criterion==0:
             # first mutation is global modularity
             if tstat[kk,0] < 0.2:


### PR DESCRIPTION
the line 96:
score = np.NaN
has trouble with the new Numpy version
changed to
score = np.nan