### PR TITLE
Fix set_files when data_dir is used

### DIFF
--- a/kilosort/run_kilosort.py
+++ b/kilosort/run_kilosort.py
@@ -364,6 +364,7 @@ def set_files(settings, filename, probe, probe_name, data_dir, results_dir,
 
         # Find binary file in the folder
         filename  = io.find_binary(data_dir=data_dir)
+        filename = [filename]
     else:
         if not isinstance(filename, list):
             filename = [filename]


### PR DESCRIPTION
This PR fixes a bug when running `set_files` with a `data_dir`, since downstream steps expect always a list of filenames