### PR TITLE
Add clustering_chunk_size to bound assign_iclust memory

### DIFF
--- a/kilosort/clustering_qr.py
+++ b/kilosort/clustering_qr.py
@@ -66,22 +66,49 @@ def neigh_mat(Xd, nskip=1, n_neigh=10, max_sub=25000):
     return kn, M
 
 
-def assign_iclust(rows_neigh, isub, kn, tones2, nclust, lam, m, ki, kj, device=torch.device('cuda')):
+def assign_iclust(rows_neigh, isub, kn, tones2, nclust, lam, m, ki, kj,
+                  device=torch.device('cuda'), chunk=None):
     n_spikes = kn.shape[0]
 
-    ij = torch.vstack((rows_neigh.flatten(), isub[kn].flatten()))
-    xN = coo(ij, tones2.flatten(), (n_spikes, nclust))
-    xN = xN.to_dense()
+    # Single-shot path: Used when chunking is disabled (chunk is None) or the center is already small.
+    if chunk is None or n_spikes <= chunk:
+        ij = torch.vstack((rows_neigh.flatten(), isub[kn].flatten()))
+        xN = coo(ij, tones2.flatten(), (n_spikes, nclust))
+        xN = xN.to_dense()
 
+        if lam > 0:
+            tones = torch.ones(len(kj), device = device)
+            tzeros = torch.zeros(len(kj), device = device)
+            ij = torch.vstack((tzeros, isub))
+            kN = coo(ij, tones, (1, nclust))
+
+            xN = xN - lam/m * (ki.unsqueeze(-1) * kN.to_dense())
+
+        iclust = torch.argmax(xN, 1)
+
+        return iclust
+
+    # Memory-bounded path: build the (n_spikes x nclust) vote matrix in row chunks
+    # instead of all at once. Each spike's row -- and therefore its argmax -- depends
+    # only on that spike's neighbors and ki, and no row is split across a chunk
+    # boundary, so the result is identical to the single-shot/unchunked path. 
+    # Peak clustering memory drops to one (chunk x nclust) tile.
     if lam > 0:
         tones = torch.ones(len(kj), device = device)
         tzeros = torch.zeros(len(kj), device = device)
-        ij = torch.vstack((tzeros, isub))    
-        kN = coo(ij, tones, (1, nclust))
-    
-        xN = xN - lam/m * (ki.unsqueeze(-1) * kN.to_dense()) 
-    
-    iclust = torch.argmax(xN, 1)
+        ij = torch.vstack((tzeros, isub))
+        kN = coo(ij, tones, (1, nclust)).to_dense()   # (1, nclust), spike-independent
+
+    iclust = torch.empty(n_spikes, dtype=torch.long, device=device)
+    for a in range(0, n_spikes, chunk):
+        b = min(a + chunk, n_spikes)
+        # rows_neigh[a:b] holds absolute row indices a..b-1; rebase to 0..(b-a-1)
+        # so this chunk's vote matrix has shape (b-a, nclust).
+        ij = torch.vstack(((rows_neigh[a:b] - a).flatten(), isub[kn[a:b]].flatten()))
+        xN = coo(ij, tones2[a:b].flatten(), (b - a, nclust)).to_dense()
+        if lam > 0:
+            xN = xN - lam/m * (ki[a:b].unsqueeze(-1) * kN)
+        iclust[a:b] = torch.argmax(xN, 1)
 
     return iclust
 
@@ -120,7 +147,7 @@ def Mstats(M, device=torch.device('cuda')):
 
 def cluster(Xd, iclust=None, kn=None, nskip=1, n_neigh=10, max_sub=25000,
             nclust=200, seed=1, niter=200, lam=0, device=torch.device('cuda'),
-            verbose=False):    
+            verbose=False, chunk=None):
 
     if kn is None:
         # kn: n_spikes by n_neigh with integer indices into the spike subset
@@ -164,7 +191,7 @@ def cluster(Xd, iclust=None, kn=None, nskip=1, n_neigh=10, max_sub=25000,
                            ki, kj,device=device)
         # given mu and isub, reassign iclust
         iclust = assign_iclust(rows_neigh, isub, kn, tones2, nclust, lam, m,
-                               ki, kj, device=device)
+                               ki, kj, device=device, chunk=chunk)
         
     if verbose:
         logger.debug(f'isub: {isub.nbytes / (2**20):.2f} MB, shape: {isub.shape}')
@@ -431,6 +458,7 @@ def run(ops, st, tF, mode='template', device=torch.device('cuda'),
     n_neigh = ops['settings']['cluster_neighbors']
     max_sub = ops['settings']['max_cluster_subset']
     seed = ops['settings']['cluster_init_seed']
+    chunk = ops['settings'].get('clustering_chunk_size', None)
     ycent = y_centers(ops)
     xcent = x_centers(ops)
     nsp = st.shape[0]
@@ -494,7 +522,7 @@ def run(ops, st, tF, mode='template', device=torch.device('cuda'),
                     # find new clusters
                     iclust, iclust0, M, _ = cluster(
                         Xd, nskip=nskip, n_neigh=n_neigh, max_sub=max_sub,
-                        lam=1, seed=seed, device=device, verbose=v
+                        lam=1, seed=seed, device=device, verbose=v, chunk=chunk
                         )
 
                     if clear_cache:

--- a/kilosort/parameters.py
+++ b/kilosort/parameters.py
@@ -464,6 +464,22 @@ EXTRA_PARAMETERS = {
             """
     },
 
+    'clustering_chunk_size': {
+        'gui_name': 'clustering chunk size', 'type': int, 'min': 1, 'max': np.inf,
+        'exclude': [], 'default': None, 'step': 'clustering',
+        'description':
+            """
+            Maximum number of spikes per chunk when assigning cluster identities
+            in the graph-clustering step (`clustering_qr.assign_iclust`). The
+            default (None) builds the full (n_spikes x n_clusters) assignment
+            matrix in one shot, which can exhaust GPU memory for very long
+            recordings (tens of millions of spikes per clustering center). When
+            set, the assignment is computed in row chunks of this size, bounding
+            peak memory to roughly one (chunk x n_clusters) tile. The clustering
+            result is identical to the unchunked path.
+            """
+    },
+
 
     ### POSTPROCESSING
     'duplicate_spike_ms': {

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,8 +1,57 @@
 import numpy as np
+import pytest
+import torch
 
-from kilosort.clustering_qr import x_centers
+from kilosort.clustering_qr import assign_iclust, x_centers
 from kilosort.io import load_probe
 from kilosort.utils import PROBE_DIR
+
+
+def _synth_assign_inputs(n_spikes, nsub, nclust, n_neigh, seed, device):
+    """Build a valid, self-consistent input set for ``assign_iclust``.
+
+    Shapes mirror what ``clustering_qr.cluster`` passes: ``rows_neigh`` and
+    ``tones2`` are (n_spikes, n_neigh); ``kn`` indexes the (nsub) graph nodes;
+    ``isub`` is the per-node cluster label; ``ki``/``kj`` are the per-spike and
+    per-node degrees (len(kj) must equal nsub == len(isub)).
+    """
+    g = torch.Generator(device=device).manual_seed(seed)
+    rows_neigh = torch.arange(n_spikes, device=device).unsqueeze(-1).tile((1, n_neigh))
+    tones2 = torch.ones((n_spikes, n_neigh), device=device)
+    kn = torch.randint(0, nsub, (n_spikes, n_neigh), generator=g, device=device)
+    isub = torch.randint(0, nclust, (nsub,), generator=g, device=device)
+    ki = torch.rand(n_spikes, generator=g, device=device) + 0.5
+    kj = torch.rand(nsub, generator=g, device=device) + 0.5
+    m = float(n_spikes * n_neigh)
+    return rows_neigh, isub, kn, tones2, ki, kj, m
+
+
+class TestAssignIclustChunking:
+    """The chunked ``assign_iclust`` path must be identical to the unchunked path."""
+
+    @pytest.mark.parametrize("lam", [0, 1])
+    @pytest.mark.parametrize("chunk", [1, 7, 333, 999, 1000, 1024, 5000, 5001])
+    def test_chunked_matches_unchunked(self, lam, chunk):
+        device = torch.device("cpu")
+        n_spikes, nsub, nclust, n_neigh = 5000, 800, 60, 10
+        rows_neigh, isub, kn, tones2, ki, kj, m = _synth_assign_inputs(
+            n_spikes, nsub, nclust, n_neigh, seed=0, device=device
+        )
+
+        full = assign_iclust(
+            rows_neigh, isub, kn, tones2, nclust, lam, m, ki, kj,
+            device=device, chunk=None,
+        )
+        chunked = assign_iclust(
+            rows_neigh, isub, kn, tones2, nclust, lam, m, ki, kj,
+            device=device, chunk=chunk,
+        )
+
+        assert chunked.shape == full.shape
+        assert chunked.dtype == full.dtype
+        # chunk >= n_spikes falls through to the fast path; smaller chunks exercise
+        # the row loop (including a ragged final chunk for non-divisor sizes).
+        assert torch.equal(full, chunked)
 
 
 def random_np2(n_chans=384, n_shanks=4):


### PR DESCRIPTION
The graph-clustering step builds a dense (n_spikes x n_clusters) assignment matrix. For very long recordings (tens of millions of spikes per clustering center) this can exhaust GPU memory.

Added an optional `clustering_chunk_size` setting that computes the assignment in row chunks, bounding peak memory to roughly one (chunk x n_clusters) tile. No row is split across a chunk boundary and each spike's argmax depends only on its own neighbors, so the result is identical to the unchunked path.